### PR TITLE
Firework recipes and some optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # AutoCraft
+
 [![GitHub release](https://img.shields.io/github/v/release/fliens/AutoCraft.svg)](https://github.com/Fliens/AutoCraft/releases)
+
 ## How to use the plugin:
+
 You want to automate everything?
 
 ![image](https://user-images.githubusercontent.com/35639879/124355511-d0c41c00-dc11-11eb-82d2-618245aa4b3b.png)
 
 This plugin takes crafting of your shoulders.
 
-Simply put an item frame (or glow item frame) with a crafting table in it on a dispenser. Put the recipe of the item you'd like to get crafted in the dispenser.
+Simply put an item frame (or glow item frame) with a crafting table in it on a dispenser. Put the recipe of the item
+you'd like to get crafted in the dispenser.
 
 ![image](https://user-images.githubusercontent.com/35639879/124355519-d7eb2a00-dc11-11eb-83b4-ec2d03890b83.png)
 
-This automatic crafting table will now take needed items out of the inventory behind it and put the crafted item in the inventory in front of it.
-Time between actions can be configured (*default is 8 ticks - hopper speed*).
+This automatic crafting table will now take needed items out of the inventory behind it and put the crafted item in the
+inventory in front of it. Time between actions can be configured (*default is 8 ticks - hopper speed*).
 
 ![image](https://user-images.githubusercontent.com/35639879/124355522-dde10b00-dc11-11eb-887f-480ef309301e.png)
 

--- a/src/fliens/autocraft/AutoCraft.java
+++ b/src/fliens/autocraft/AutoCraft.java
@@ -38,6 +38,8 @@ public class AutoCraft extends JavaPlugin {
 	String redstoneMode;
 	long craftCooldown;
 
+	ArrayList<Recipe> recipes = new ArrayList<>();
+
 	@Override
 	public void onEnable() {
 		super.onEnable();
@@ -47,6 +49,8 @@ public class AutoCraft extends JavaPlugin {
 		craftCooldown = getConfig().getLong("craftCooldown");
 		particles = getConfig().getBoolean("particles");
 		redstoneMode = getConfig().getString("redstoneMode");
+
+		recipes = collectRecipes();
 
 		new EventListener(this);
 		BukkitScheduler scheduler = getServer().getScheduler();
@@ -83,6 +87,16 @@ public class AutoCraft extends JavaPlugin {
 	public void onDisable() {
 		super.onDisable();
 		getLogger().info("AutoCraft plugin stopped");
+	}
+
+	public ArrayList<Recipe> collectRecipes(){
+		ArrayList<Recipe> recipes = new ArrayList<>();
+		Iterator<Recipe> it = getServer().recipeIterator();
+		while (it.hasNext()) {
+			Recipe recipe = it.next();
+			recipes.add(recipe);
+		}
+		return recipes;
 	}
 
 	private void handleAutoCrafter(Block autocrafter) {
@@ -178,12 +192,6 @@ public class AutoCraft extends JavaPlugin {
 	private ItemStack getCraftResult(List<ItemStack> items) {
 		if (cache.containsKey(items))
 			return cache.get(items);
-		List<Recipe> recipes = new ArrayList<>();
-		Iterator<Recipe> it = getServer().recipeIterator();
-		while (it.hasNext()) {
-			Recipe rec = it.next();
-			recipes.add(rec);
-		}
 
 		if (items.size() != 9) { // list correct?
 			return null;

--- a/src/fliens/autocraft/AutoCraft.java
+++ b/src/fliens/autocraft/AutoCraft.java
@@ -27,6 +27,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.inventory.*;
+import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 
@@ -34,337 +35,377 @@ import java.util.*;
 
 public class AutoCraft extends JavaPlugin {
 
-	boolean particles;
-	String redstoneMode;
-	long craftCooldown;
+    boolean particles;
+    String redstoneMode;
+    long craftCooldown;
 
-	ArrayList<Recipe> recipes = new ArrayList<>();
+    ArrayList<Recipe> recipes = new ArrayList<>();
 
-	@Override
-	public void onEnable() {
-		super.onEnable();
-		getLogger().info("AutoCraft plugin started");
+    @Override
+    public void onEnable() {
+        super.onEnable();
+        getLogger().info("AutoCraft plugin started");
 
-		saveDefaultConfig();
-		craftCooldown = getConfig().getLong("craftCooldown");
-		particles = getConfig().getBoolean("particles");
-		redstoneMode = getConfig().getString("redstoneMode");
+        saveDefaultConfig();
+        craftCooldown = getConfig().getLong("craftCooldown");
+        particles = getConfig().getBoolean("particles");
+        redstoneMode = getConfig().getString("redstoneMode");
 
-		recipes = collectRecipes();
+        recipes = collectRecipes();
 
-		new EventListener(this);
-		BukkitScheduler scheduler = getServer().getScheduler();
-		scheduler.scheduleSyncRepeatingTask(this, () -> {
-			List<Block> autoCrafters = new ArrayList<>();
-			for (World world : Bukkit.getWorlds()) {
-				for (Chunk chunk : world.getLoadedChunks()) {
-					for (Entity entity : chunk.getEntities()) {
-						if (entity.getType().equals(EntityType.ITEM_FRAME) || entity.getType().equals(EntityType.GLOW_ITEM_FRAME)) {
-							if (((ItemFrame) entity).getItem().equals(new ItemStack(Material.CRAFTING_TABLE))) {
-								Block autoCrafter = entity.getLocation().getBlock()
-										.getRelative(((ItemFrame) entity).getAttachedFace());
-								if (!autoCrafters.contains(autoCrafter)
-										&& autoCrafter.getType().equals(Material.DISPENSER)) {
-									autoCrafters.add(autoCrafter);
-								}
-							}
-						}
-					}
-				}
-			} // redstone powering type check
-			for (final Block autocrafter : autoCrafters) {
-				if (!redstoneMode.equalsIgnoreCase("disabled")) {
-					if ((redstoneMode.equalsIgnoreCase("indirect") && autocrafter.isBlockIndirectlyPowered()) || autocrafter.isBlockPowered()) {
-						continue;
-					}
-				}
-				handleAutoCrafter(autocrafter);
-			}
-		}, 0L, craftCooldown);// configurable cooldown
-	}
+        new EventListener(this);
+        BukkitScheduler scheduler = getServer().getScheduler();
+        scheduler.scheduleSyncRepeatingTask(this, () -> {
+            List<Block> autoCrafters = new ArrayList<>();
+            for (World world : Bukkit.getWorlds()) {
+                for (Chunk chunk : world.getLoadedChunks()) {
+                    for (Entity entity : chunk.getEntities()) {
+                        if (entity.getType().equals(EntityType.ITEM_FRAME) || entity.getType().equals(EntityType.GLOW_ITEM_FRAME)) {
+                            if (((ItemFrame) entity).getItem().equals(new ItemStack(Material.CRAFTING_TABLE))) {
+                                Block autoCrafter = entity.getLocation().getBlock()
+                                        .getRelative(((ItemFrame) entity).getAttachedFace());
+                                if (!autoCrafters.contains(autoCrafter)
+                                        && autoCrafter.getType().equals(Material.DISPENSER)) {
+                                    autoCrafters.add(autoCrafter);
+                                }
+                            }
+                        }
+                    }
+                }
+            } // redstone powering type check
+            for (final Block autocrafter : autoCrafters) {
+                if (!redstoneMode.equalsIgnoreCase("disabled")) {
+                    if ((redstoneMode.equalsIgnoreCase("indirect") && autocrafter.isBlockIndirectlyPowered()) || autocrafter.isBlockPowered()) {
+                        continue;
+                    }
+                }
+                handleAutoCrafter(autocrafter);
+            }
+        }, 0L, craftCooldown);// configurable cooldown
+    }
 
-	@Override
-	public void onDisable() {
-		super.onDisable();
-		getLogger().info("AutoCraft plugin stopped");
-	}
+    @Override
+    public void onDisable() {
+        super.onDisable();
+        getLogger().info("AutoCraft plugin stopped");
+    }
 
-	public ArrayList<Recipe> collectRecipes(){
-		ArrayList<Recipe> recipes = new ArrayList<>();
-		Iterator<Recipe> it = getServer().recipeIterator();
-		while (it.hasNext()) {
-			Recipe recipe = it.next();
-			recipes.add(recipe);
-		}
-		return recipes;
-	}
+    public ArrayList<Recipe> collectRecipes() {
+        ArrayList<Recipe> recipes = new ArrayList<>();
+        Iterator<Recipe> it = getServer().recipeIterator();
+        while (it.hasNext()) {
+            Recipe recipe = it.next();
+            if (recipe.getResult().getType() == Material.FIREWORK_ROCKET)
+                continue; // skipping duplicating recipe with no NBT
+            recipes.add(recipe);
+        }
 
-	private void handleAutoCrafter(Block autocrafter) {
-		Dispenser dispenser = (Dispenser) autocrafter.getState();
-		BlockFace targetFace = ((org.bukkit.block.data.type.Dispenser) autocrafter.getBlockData()).getFacing();
-		BlockState source = new Location(autocrafter.getWorld(),
-				autocrafter.getX() + targetFace.getOppositeFace().getModX(),
-				autocrafter.getY() + targetFace.getOppositeFace().getModY(),
-				autocrafter.getZ() + targetFace.getOppositeFace().getModZ()).getBlock().getState();
-		BlockState destination = new Location(autocrafter.getWorld(), autocrafter.getX() + targetFace.getModX(),
-				autocrafter.getY() + targetFace.getModY(), autocrafter.getZ() + targetFace.getModZ()).getBlock()
-						.getState();
-		if (source instanceof InventoryHolder && destination instanceof InventoryHolder) {
-			Inventory sourceInv = ((InventoryHolder) source).getInventory();
-			Inventory destinationInv = ((InventoryHolder) destination).getInventory();
-			List<ItemStack> crafterItems = new ArrayList<>(Arrays.asList(dispenser.getInventory().getContents()));
-			if (crafterItems.stream().noneMatch(Objects::nonNull)) // test if crafter is empty
-				return;
+        recipes.addAll(collectExtraRecipes());
 
-			List<ItemStack> itemstmp = new ArrayList<>();
-			List<ItemStack> itemsrem = new ArrayList<>();
-			for (ItemStack item : crafterItems) {
-				if (item != null) {
-					if (itemstmp.stream().noneMatch(i -> i.isSimilar(item))) {
-						int count = 0;
-						for (ItemStack jtem : crafterItems) {
-							if (jtem != null) {
-								if (jtem.isSimilar(item)) {
-									count += 1;
-								}
-							}
-						}
-						ItemStack tmpitem = new ItemStack(item);
-						tmpitem.setAmount(count);
-						itemstmp.add(tmpitem);
+        return recipes;
+    }
 
-						Material remMat = item.getType().getCraftingRemainingItem(); // fix for lost bottles/buckets by avixk
-						if(remMat != null && !remMat.isAir()){
-							itemsrem.add(new ItemStack(remMat, count));
-						}
-					}
-				}
-			}
-			for (ItemStack i : itemstmp)
-				if (!sourceInv.containsAtLeast(i, i.getAmount()))
-					return;
-			ItemStack result = getCraftResult(crafterItems);
-			if (result == null)
-				return;
+    public ArrayList<Recipe> collectExtraRecipes() {
+        ArrayList<Recipe> recipes = new ArrayList<>();
 
-			ArrayList<ItemStack> output = new ArrayList<>(); // Making a list of items to add to the output container
-			output.add(result.clone());
-			output.addAll(itemsrem);
+        ItemStack rocket_1 = new ItemStack(Material.FIREWORK_ROCKET, 3);
+        FireworkMeta rocket_1_meta = (FireworkMeta) rocket_1.getItemMeta();
+        rocket_1_meta.setPower(1);
+        rocket_1.setItemMeta(rocket_1_meta);
+        ShapelessRecipe rocket_1_recipe = new ShapelessRecipe(new NamespacedKey(this, "fliens.autocraft.firework_rocket_1"), rocket_1);
+        rocket_1_recipe.addIngredient(Material.PAPER);
+        rocket_1_recipe.addIngredient(1, Material.GUNPOWDER);
 
-			if(!addItemsIfCan(destinationInv, output)) // Trying to add
-				return;
+        ItemStack rocket_2 = new ItemStack(Material.FIREWORK_ROCKET, 3);
+        FireworkMeta rocket_2_meta = (FireworkMeta) rocket_2.getItemMeta();
+        rocket_2_meta.setPower(2);
+        rocket_2.setItemMeta(rocket_2_meta);
+        ShapelessRecipe rocket_2_recipe = new ShapelessRecipe(new NamespacedKey(this, "fliens.autocraft.firework_rocket_2"), rocket_2);
+        rocket_2_recipe.addIngredient(Material.PAPER);
+        rocket_2_recipe.addIngredient(2, Material.GUNPOWDER);
 
-			for (ItemStack item : itemstmp) {
-				for (int i = 0; i < item.getAmount(); i++) {
-					for (ItemStack sourceItem : sourceInv.getContents()) {
-						if (sourceItem != null) {
-							if (sourceItem.isSimilar(item)) {
-								sourceItem.setAmount(sourceItem.getAmount() - 1);
-								break;
-							}
-						}
-					}
-				}
-			}
-			if (particles)
-				for (Location loc : getHollowCube(autocrafter.getLocation(), 0.05))
-					loc.getWorld().spawnParticle(Particle.REDSTONE, loc, 2, 0, 0, 0, 0,
-							new Particle.DustOptions(Color.LIME, 0.2F));
-		}
-	}
+        ItemStack rocket_3 = new ItemStack(Material.FIREWORK_ROCKET, 3);
+        FireworkMeta rocket_3_meta = (FireworkMeta) rocket_3.getItemMeta();
+        rocket_3_meta.setPower(3);
+        rocket_3.setItemMeta(rocket_3_meta);
+        ShapelessRecipe rocket_3_recipe = new ShapelessRecipe(new NamespacedKey(this, "fliens.autocraft.firework_rocket_3"), rocket_3);
+        rocket_3_recipe.addIngredient(Material.PAPER);
+        rocket_3_recipe.addIngredient(3, Material.GUNPOWDER);
 
-	private boolean addItemsIfCan(Inventory inventory, ArrayList<ItemStack> items){ // I think this needs explanation
-		ItemStack[] mutableCont = inventory.getContents(); // We have to manually clone each ItemStack to prevent them from
-		ItemStack[] contents = inventory.getContents(); // mutation when adding items. This is the backup inventory
-		for(int i = 0; i < mutableCont.length; i++) contents[i] = mutableCont[i] == null ? null : mutableCont[i].clone();
-		for(ItemStack item : items){
-			Map<Integer, ItemStack> left = inventory.addItem(item.clone()); // addItem() returns a map of items which didn`t fit
-			if(!left.isEmpty()){
-				inventory.setStorageContents(contents);// if so, we rollback the inventory
-				return false;
-			}
-		}
-		return true;
-	}
+        recipes.add(rocket_1_recipe);
+        recipes.add(rocket_2_recipe);
+        recipes.add(rocket_3_recipe);
 
-	private final Map<List<ItemStack>, ItemStack> cache = new HashMap<>();
+        return recipes;
+    }
 
-	private ItemStack getCraftResult(List<ItemStack> items) {
-		if (cache.containsKey(items))
-			return cache.get(items);
+    private void handleAutoCrafter(Block autocrafter) {
+        Dispenser dispenser = (Dispenser) autocrafter.getState();
+        BlockFace targetFace = ((org.bukkit.block.data.type.Dispenser) autocrafter.getBlockData()).getFacing();
+        BlockState source = new Location(autocrafter.getWorld(),
+                autocrafter.getX() + targetFace.getOppositeFace().getModX(),
+                autocrafter.getY() + targetFace.getOppositeFace().getModY(),
+                autocrafter.getZ() + targetFace.getOppositeFace().getModZ()).getBlock().getState();
+        BlockState destination = new Location(autocrafter.getWorld(), autocrafter.getX() + targetFace.getModX(),
+                autocrafter.getY() + targetFace.getModY(), autocrafter.getZ() + targetFace.getModZ()).getBlock()
+                .getState();
+        if (source instanceof InventoryHolder && destination instanceof InventoryHolder) {
+            Inventory sourceInv = ((InventoryHolder) source).getInventory();
+            Inventory destinationInv = ((InventoryHolder) destination).getInventory();
+            List<ItemStack> crafterItems = new ArrayList<>(Arrays.asList(dispenser.getInventory().getContents()));
+            if (crafterItems.stream().noneMatch(Objects::nonNull)) // test if crafter is empty
+                return;
 
-		if (items.size() != 9) { // list correct?
-			return null;
-		}
-		boolean notNull = false;
-		for (ItemStack itemstack : items) {
-			if (itemstack != null) {
-				notNull = true;
-				break;
-			}
-		}
-		if (!notNull) {
-			return null;
-		}
+            List<ItemStack> itemstmp = new ArrayList<>();
+            List<ItemStack> itemsrem = new ArrayList<>();
+            for (ItemStack item : crafterItems) {
+                if (item != null) {
+                    if (itemstmp.stream().noneMatch(i -> i.isSimilar(item))) {
+                        int count = 0;
+                        for (ItemStack jtem : crafterItems) {
+                            if (jtem != null) {
+                                if (jtem.isSimilar(item)) {
+                                    count += 1;
+                                }
+                            }
+                        }
+                        ItemStack tmpitem = new ItemStack(item);
+                        tmpitem.setAmount(count);
+                        itemstmp.add(tmpitem);
 
-		ItemStack result;
-		for (Recipe recipe : recipes) {
-			if (recipe instanceof ShapelessRecipe) { // shapeless recipe
-				result = matchesShapeless(((ShapelessRecipe) recipe).getChoiceList(), items) ? recipe.getResult()
-						: null;
-				if (result != null) {
-					cache.put(items, result);
-					return result;
-				}
-			} else if (recipe instanceof ShapedRecipe) { // shaped recipe
-				result = matchesShaped((ShapedRecipe) recipe, items) ? recipe.getResult() : null;
-				if (result != null) {
-					cache.put(items, result);
-					return result;
-				}
-			}
-		}
-		return null;
-	}
+                        Material remMat = item.getType().getCraftingRemainingItem(); // fix for lost bottles/buckets by avixk
+                        if (remMat != null && !remMat.isAir()) {
+                            itemsrem.add(new ItemStack(remMat, count));
+                        }
+                    }
+                }
+            }
+            for (ItemStack i : itemstmp)
+                if (!sourceInv.containsAtLeast(i, i.getAmount()))
+                    return;
+            ItemStack result = getCraftResult(crafterItems);
+            if (result == null)
+                return;
 
-	private boolean matchesShapeless(List<RecipeChoice> choice, List<ItemStack> items) {
-		items = new ArrayList<>(items);
-		for (RecipeChoice c : choice) {
-			boolean match = false;
-			for (int i = 0; i < items.size(); i++) {
-				ItemStack item = items.get(i);
-				if (item == null || item.getType() == Material.AIR)
-					continue;
-				if (c.test(item)) {
-					match = true;
-					items.remove(item);
-					break;
-				}
-			}
-			if (!match)
-				return false;
-		}
-		items.removeAll(Arrays.asList(null, new ItemStack(Material.AIR)));
-		return items.size() == 0;
-	}
+            ArrayList<ItemStack> output = new ArrayList<>(); // Making a list of items to add to the output container
+            output.add(result.clone());
+            output.addAll(itemsrem);
 
-	private boolean matchesShaped(ShapedRecipe recipe, List<ItemStack> items) {
-		RecipeChoice[][] recipeArray = new RecipeChoice[recipe.getShape().length][recipe.getShape()[0].length()];
-		for (int i = 0; i < recipe.getShape().length; i++) {
-			for (int j = 0; j < recipe.getShape()[i].length(); j++) {
-				recipeArray[i][j] = recipe.getChoiceMap().get(recipe.getShape()[i].toCharArray()[j]);
-			}
-		}
+            if (!addItemsIfCan(destinationInv, output)) // Trying to add
+                return;
 
-		int counter = 0;
-		ItemStack[][] itemsArray = new ItemStack[3][3];
-		for (int i = 0; i < itemsArray.length; i++) {
-			for (int j = 0; j < itemsArray[i].length; j++) {
-				itemsArray[i][j] = items.get(counter);
-				counter++;
-			}
-		}
+            for (ItemStack item : itemstmp) {
+                for (int i = 0; i < item.getAmount(); i++) {
+                    for (ItemStack sourceItem : sourceInv.getContents()) {
+                        if (sourceItem != null) {
+                            if (sourceItem.isSimilar(item)) {
+                                sourceItem.setAmount(sourceItem.getAmount() - 1);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            if (particles)
+                for (Location loc : getHollowCube(autocrafter.getLocation(), 0.05))
+                    loc.getWorld().spawnParticle(Particle.REDSTONE, loc, 2, 0, 0, 0, 0,
+                            new Particle.DustOptions(Color.LIME, 0.2F));
+        }
+    }
 
-		// itemsArray manipulation
-		Object[][] tmpArray = reduceArray(itemsArray);
-		itemsArray = new ItemStack[tmpArray.length][tmpArray[0].length];
-		for (int i = 0; i < tmpArray.length; i++) {
-			for (int j = 0; j < tmpArray[i].length; j++) {
-				itemsArray[i][j] = (ItemStack) tmpArray[i][j];
-			}
-		}
-		ItemStack[][] itemsArrayGespiegelt = new ItemStack[itemsArray.length][itemsArray[0].length];
-		for (int i = 0; i < itemsArray.length; i++) {
-			int jPos = 0;
-			for (int j = itemsArray[i].length - 1; j >= 0; j--) {
-				itemsArrayGespiegelt[i][jPos] = itemsArray[i][j];
-				jPos++;
-			}
-		}
-		return match(itemsArray, recipeArray) || match(itemsArrayGespiegelt, recipeArray);
-	}
+    private boolean addItemsIfCan(Inventory inventory, ArrayList<ItemStack> items) { // I think this needs explanation
+        ItemStack[] mutableCont = inventory.getContents(); // We have to manually clone each ItemStack to prevent them from
+        ItemStack[] contents = inventory.getContents(); // mutation when adding items. This is the backup inventory
+        for (int i = 0; i < mutableCont.length; i++)
+            contents[i] = mutableCont[i] == null ? null : mutableCont[i].clone();
+        for (ItemStack item : items) {
+            Map<Integer, ItemStack> left = inventory.addItem(item.clone()); // addItem() returns a map of items which didn`t fit
+            if (!left.isEmpty()) {
+                inventory.setStorageContents(contents);// if so, we rollback the inventory
+                return false;
+            }
+        }
+        return true;
+    }
 
-	private boolean match(ItemStack[][] itemsArray, RecipeChoice[][] recipeArray) {
-		boolean match = true;
-		if (itemsArray.length == recipeArray.length && itemsArray[0].length == recipeArray[0].length) {
-			for (int i = 0; i < recipeArray.length; i++) {
-				for (int j = 0; j < recipeArray[0].length; j++) {
-					if (recipeArray[i][j] != null && itemsArray[i][j] != null) {
-						if (!recipeArray[i][j].test(itemsArray[i][j])) {
-							match = false;
-							break;
-						}
-					} else if ((recipeArray[i][j] == null && itemsArray[i][j] != null)
-							|| (recipeArray[i][j] != null && itemsArray[i][j] == null)) {
-						match = false;
-						break;
-					}
-				}
-			}
-			return match;
-		}
-		return false;
-	}
+    private final Map<List<ItemStack>, ItemStack> cache = new HashMap<>();
 
-	private static Object[][] reduceArray(Object[][] array) {
-		ArrayList<Pos> positionen = new ArrayList<>();
-		for (int y = 0; y < array.length; y++)
-			for (int x = 0; x < array[y].length; x++) {
-				if (array[y][x] != null)
-					positionen.add(new Pos(x, y));
-			}
+    private ItemStack getCraftResult(List<ItemStack> items) {
+        if (cache.containsKey(items))
+            return cache.get(items);
 
-		Pos upperLeft = new Pos(array.length - 1, array[0].length - 1);
-		Pos lowerRight = new Pos(0, 0);
-		for (Pos pos : positionen) {
-			if (pos.y < upperLeft.y)
-				upperLeft.y = pos.y;
-			if (pos.x < upperLeft.x)
-				upperLeft.x = pos.x;
-			if (pos.y > lowerRight.y)
-				lowerRight.y = pos.y;
-			if (pos.x > lowerRight.x)
-				lowerRight.x = pos.x;
-		}
-		Object[][] clean = new Object[(lowerRight.y - upperLeft.y) + 1][(lowerRight.x - upperLeft.x) + 1];
-		int cleanyY = 0;
-		for (int y = upperLeft.y; y < lowerRight.y + 1; y++) {
-			int cleanxX = 0;
-			for (int x = upperLeft.x; x < lowerRight.x + 1; x++) {
-				clean[cleanyY][cleanxX] = array[y][x];
-				cleanxX++;
-			}
-			cleanyY++;
-		}
-		return clean;
-	}
+        if (items.size() != 9) { // list correct?
+            return null;
+        }
+        boolean notNull = false;
+        for (ItemStack itemstack : items) {
+            if (itemstack != null) {
+                notNull = true;
+                break;
+            }
+        }
+        if (!notNull) {
+            return null;
+        }
 
-	public List<Location> getHollowCube(Location loc, double particleDistance) {
-		List<Location> result = new ArrayList<>();
-		World world = loc.getWorld();
-		double minX = loc.getBlockX();
-		double minY = loc.getBlockY();
-		double minZ = loc.getBlockZ();
-		double maxX = loc.getBlockX() + 1;
-		double maxY = loc.getBlockY() + 1;
-		double maxZ = loc.getBlockZ() + 1;
+        ItemStack result;
+        for (Recipe recipe : recipes) {
+            if (recipe instanceof ShapelessRecipe) { // shapeless recipe
+                result = matchesShapeless(((ShapelessRecipe) recipe).getChoiceList(), items) ? recipe.getResult()
+                        : null;
+                if (result != null) {
+                    cache.put(items, result);
+                    return result;
+                }
+            } else if (recipe instanceof ShapedRecipe) { // shaped recipe
+                result = matchesShaped((ShapedRecipe) recipe, items) ? recipe.getResult() : null;
+                if (result != null) {
+                    cache.put(items, result);
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
 
-		for (double x = minX; x <= maxX; x = Math.round((x + particleDistance) * 1e2) / 1e2) {
-			for (double y = minY; y <= maxY; y = Math.round((y + particleDistance) * 1e2) / 1e2) {
-				for (double z = minZ; z <= maxZ; z = Math.round((z + particleDistance) * 1e2) / 1e2) {
-					int components = 0;
-					if (x == minX || x == maxX)
-						components++;
-					if (y == minY || y == maxY)
-						components++;
-					if (z == minZ || z == maxZ)
-						components++;
-					if (components >= 2) {
-						result.add(new Location(world, x, y, z));
-					}
-				}
-			}
-		}
-		return result;
-	}
+    private boolean matchesShapeless(List<RecipeChoice> choice, List<ItemStack> items) {
+        items = new ArrayList<>(items);
+        for (RecipeChoice c : choice) {
+            boolean match = false;
+            for (int i = 0; i < items.size(); i++) {
+                ItemStack item = items.get(i);
+                if (item == null || item.getType() == Material.AIR)
+                    continue;
+                if (c.test(item)) {
+                    match = true;
+                    items.remove(item);
+                    break;
+                }
+            }
+            if (!match)
+                return false;
+        }
+        items.removeAll(Arrays.asList(null, new ItemStack(Material.AIR)));
+        return items.size() == 0;
+    }
+
+    private boolean matchesShaped(ShapedRecipe recipe, List<ItemStack> items) {
+        RecipeChoice[][] recipeArray = new RecipeChoice[recipe.getShape().length][recipe.getShape()[0].length()];
+        for (int i = 0; i < recipe.getShape().length; i++) {
+            for (int j = 0; j < recipe.getShape()[i].length(); j++) {
+                recipeArray[i][j] = recipe.getChoiceMap().get(recipe.getShape()[i].toCharArray()[j]);
+            }
+        }
+
+        int counter = 0;
+        ItemStack[][] itemsArray = new ItemStack[3][3];
+        for (int i = 0; i < itemsArray.length; i++) {
+            for (int j = 0; j < itemsArray[i].length; j++) {
+                itemsArray[i][j] = items.get(counter);
+                counter++;
+            }
+        }
+
+        // itemsArray manipulation
+        Object[][] tmpArray = reduceArray(itemsArray);
+        itemsArray = new ItemStack[tmpArray.length][tmpArray[0].length];
+        for (int i = 0; i < tmpArray.length; i++) {
+            for (int j = 0; j < tmpArray[i].length; j++) {
+                itemsArray[i][j] = (ItemStack) tmpArray[i][j];
+            }
+        }
+        ItemStack[][] itemsArrayGespiegelt = new ItemStack[itemsArray.length][itemsArray[0].length];
+        for (int i = 0; i < itemsArray.length; i++) {
+            int jPos = 0;
+            for (int j = itemsArray[i].length - 1; j >= 0; j--) {
+                itemsArrayGespiegelt[i][jPos] = itemsArray[i][j];
+                jPos++;
+            }
+        }
+        return match(itemsArray, recipeArray) || match(itemsArrayGespiegelt, recipeArray);
+    }
+
+    private boolean match(ItemStack[][] itemsArray, RecipeChoice[][] recipeArray) {
+        boolean match = true;
+        if (itemsArray.length == recipeArray.length && itemsArray[0].length == recipeArray[0].length) {
+            for (int i = 0; i < recipeArray.length; i++) {
+                for (int j = 0; j < recipeArray[0].length; j++) {
+                    if (recipeArray[i][j] != null && itemsArray[i][j] != null) {
+                        if (!recipeArray[i][j].test(itemsArray[i][j])) {
+                            match = false;
+                            break;
+                        }
+                    } else if ((recipeArray[i][j] == null && itemsArray[i][j] != null)
+                            || (recipeArray[i][j] != null && itemsArray[i][j] == null)) {
+                        match = false;
+                        break;
+                    }
+                }
+            }
+            return match;
+        }
+        return false;
+    }
+
+    private static Object[][] reduceArray(Object[][] array) {
+        ArrayList<Pos> positionen = new ArrayList<>();
+        for (int y = 0; y < array.length; y++)
+            for (int x = 0; x < array[y].length; x++) {
+                if (array[y][x] != null)
+                    positionen.add(new Pos(x, y));
+            }
+
+        Pos upperLeft = new Pos(array.length - 1, array[0].length - 1);
+        Pos lowerRight = new Pos(0, 0);
+        for (Pos pos : positionen) {
+            if (pos.y < upperLeft.y)
+                upperLeft.y = pos.y;
+            if (pos.x < upperLeft.x)
+                upperLeft.x = pos.x;
+            if (pos.y > lowerRight.y)
+                lowerRight.y = pos.y;
+            if (pos.x > lowerRight.x)
+                lowerRight.x = pos.x;
+        }
+        Object[][] clean = new Object[(lowerRight.y - upperLeft.y) + 1][(lowerRight.x - upperLeft.x) + 1];
+        int cleanyY = 0;
+        for (int y = upperLeft.y; y < lowerRight.y + 1; y++) {
+            int cleanxX = 0;
+            for (int x = upperLeft.x; x < lowerRight.x + 1; x++) {
+                clean[cleanyY][cleanxX] = array[y][x];
+                cleanxX++;
+            }
+            cleanyY++;
+        }
+        return clean;
+    }
+
+    public List<Location> getHollowCube(Location loc, double particleDistance) {
+        List<Location> result = new ArrayList<>();
+        World world = loc.getWorld();
+        double minX = loc.getBlockX();
+        double minY = loc.getBlockY();
+        double minZ = loc.getBlockZ();
+        double maxX = loc.getBlockX() + 1;
+        double maxY = loc.getBlockY() + 1;
+        double maxZ = loc.getBlockZ() + 1;
+
+        for (double x = minX; x <= maxX; x = Math.round((x + particleDistance) * 1e2) / 1e2) {
+            for (double y = minY; y <= maxY; y = Math.round((y + particleDistance) * 1e2) / 1e2) {
+                for (double z = minZ; z <= maxZ; z = Math.round((z + particleDistance) * 1e2) / 1e2) {
+                    int components = 0;
+                    if (x == minX || x == maxX)
+                        components++;
+                    if (y == minY || y == maxY)
+                        components++;
+                    if (z == minZ || z == maxZ)
+                        components++;
+                    if (components >= 2) {
+                        result.add(new Location(world, x, y, z));
+                    }
+                }
+            }
+        }
+        return result;
+    }
 }

--- a/src/fliens/autocraft/EventListener.java
+++ b/src/fliens/autocraft/EventListener.java
@@ -36,37 +36,37 @@ import org.bukkit.event.block.BlockDispenseEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 
-public class EventListener implements Listener{
-	
-	public EventListener(Plugin plugin) { // changed to generic Plugin
-		plugin.getServer().getPluginManager().registerEvents(this, plugin);
-	}
-	
-	@EventHandler
-	public void onItemMove(BlockDispenseEvent e) {
-		if(e.getBlock().getType().equals(Material.DISPENSER)) {
-			List<Block> autoCrafters = new ArrayList<>();
+public class EventListener implements Listener {
 
-			for (World world : Bukkit.getWorlds()) {
-				for (Chunk chunk : world.getLoadedChunks()) {
-					for (Entity entity : chunk.getEntities()) {
-						if (entity.getType().equals(EntityType.ITEM_FRAME) || entity.getType().equals(EntityType.GLOW_ITEM_FRAME)) {
-							if (((ItemFrame) entity).getItem().equals(new ItemStack(Material.CRAFTING_TABLE))) {
-								Block autoCrafter = entity.getLocation().getBlock()
-										.getRelative(((ItemFrame) entity).getAttachedFace());
-								if (!autoCrafters.contains(autoCrafter)
-										&& autoCrafter.getType().equals(Material.DISPENSER)) {
-									autoCrafters.add(autoCrafter);
-								}
-							}
-						}
-					}
-				}
-			}
-			if(autoCrafters.contains(e.getBlock())) {
-				e.setCancelled(true);
-			}
-		}
-	}
-	
+    public EventListener(Plugin plugin) { // changed to generic Plugin
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void onItemMove(BlockDispenseEvent e) {
+        if (e.getBlock().getType().equals(Material.DISPENSER)) {
+            List<Block> autoCrafters = new ArrayList<>();
+
+            for (World world : Bukkit.getWorlds()) {
+                for (Chunk chunk : world.getLoadedChunks()) {
+                    for (Entity entity : chunk.getEntities()) {
+                        if (entity.getType().equals(EntityType.ITEM_FRAME) || entity.getType().equals(EntityType.GLOW_ITEM_FRAME)) {
+                            if (((ItemFrame) entity).getItem().equals(new ItemStack(Material.CRAFTING_TABLE))) {
+                                Block autoCrafter = entity.getLocation().getBlock()
+                                        .getRelative(((ItemFrame) entity).getAttachedFace());
+                                if (!autoCrafters.contains(autoCrafter)
+                                        && autoCrafter.getType().equals(Material.DISPENSER)) {
+                                    autoCrafters.add(autoCrafter);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (autoCrafters.contains(e.getBlock())) {
+                e.setCancelled(true);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Took me a literal eternity to figure out how to move this changes to a separate branch but here we are.
Changelog:
1) Moved recipe collection from getCraftResult() to onEnable() to reduce lag (getCraftResult() was updating recipe list every time a non-cached recipe is added)
2) Added firework rocket recipes using avixk's method + removed duplicating recipe in recipe book (what was happening is that the original recipe was used instead so 1-rockets were crafted into non-NBT ones)