### PR TITLE
Added config version checkout

### DIFF
--- a/src/main/java/fliens/autocraft/AutoCraft.java
+++ b/src/main/java/fliens/autocraft/AutoCraft.java
@@ -38,11 +38,13 @@ import java.util.*;
 
 public class AutoCraft extends JavaPlugin {
 
-    boolean particles;
-    String redstoneMode;
-    long craftCooldown;
+    private boolean particles;
+    private String redstoneMode;
+    private long craftCooldown;
+    public static boolean allowBlockRecipeModification;
 
-    ArrayList<Recipe> recipes = new ArrayList<>();
+    public static ArrayList<Block> autoCrafters;
+    private ArrayList<Recipe> recipes = new ArrayList<>();
 
     @Override
     public void onEnable() {
@@ -51,16 +53,14 @@ public class AutoCraft extends JavaPlugin {
 
         checkConfigFile();
 
-        craftCooldown = getConfig().getLong("craftCooldown");
-        particles = getConfig().getBoolean("particles");
-        redstoneMode = getConfig().getString("redstoneMode");
+        updateConfig();
 
         recipes = collectRecipes();
 
         new EventListener(this);
         BukkitScheduler scheduler = getServer().getScheduler();
         scheduler.scheduleSyncRepeatingTask(this, () -> {
-            ArrayList<Block> autoCrafters = collectAutoCrafters();
+            autoCrafters = collectAutoCrafters();
 
             for (final Block autocrafter : autoCrafters) {
                 if (!redstoneMode.equalsIgnoreCase("disabled")) { // redstone powering type check
@@ -233,6 +233,17 @@ public class AutoCraft extends JavaPlugin {
 
     private File getFile(String fileName){
         return new File(getDataFolder(), fileName.replace('/', File.separatorChar));
+    }
+
+    /**
+     * This method reloads values from config file
+     */
+
+    private void updateConfig(){
+        craftCooldown = getConfig().getLong("craftCooldown");
+        particles = getConfig().getBoolean("particles");
+        redstoneMode = getConfig().getString("redstoneMode");
+        allowBlockRecipeModification = getConfig().getBoolean("allowBlockRecipeModification");
     }
 
     /**

--- a/src/main/java/fliens/autocraft/EventListener.java
+++ b/src/main/java/fliens/autocraft/EventListener.java
@@ -24,6 +24,9 @@ import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.Plugin;
 
 import java.util.List;
@@ -46,4 +49,19 @@ public class EventListener implements Listener {
         }
     }
 
+    @EventHandler
+    public void onHopperDropperItemMove(InventoryMoveItemEvent e) {
+        if (AutoCraft.allowBlockRecipeModification) return;
+
+        Inventory initiatior = e.getInitiator();
+
+        if (initiatior.getType() == InventoryType.HOPPER || initiatior.getType() == InventoryType.DROPPER) {
+            Inventory source = e.getSource();
+            Inventory destination = e.getDestination();
+            if (source.getType() == InventoryType.DISPENSER && AutoCraft.autoCrafters.contains(source.getLocation().getBlock()))
+                e.setCancelled(true);
+            else if (destination.getType() == InventoryType.DISPENSER && AutoCraft.autoCrafters.contains(destination.getLocation().getBlock()))
+                e.setCancelled(true);
+        }
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,6 @@
 craftCooldown: 8
 redstoneMode: 'indirect'
 particles: true
+
+# DO NOT CHANGE THIS NUMBER BECAUSE IT WILL RESET YOUR CONFIG
+config-version: 1

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,17 @@
+# Time between crafts in ticks
 craftCooldown: 8
+
+# Configures if crafters can be disabled with redstone input
+# values: 'disabled', 'direct', 'indirect'
+# 'direct' - crafter can be disabled only with direct powering from redstone dust/components
+# 'indirect' - crafter can be disabled by powering a block next to it (doesn't allow quasi-connectivity to disable crafters)
 redstoneMode: 'indirect'
+
+# Configures if crafters should be highlighted with green particles when crafting
 particles: true
 
+# Configures whether hoppers/dispensers can move items in and out of crafter inventory
+allowBlockRecipeModification: true
+
 # DO NOT CHANGE THIS NUMBER BECAUSE IT WILL RESET YOUR CONFIG
-config-version: 1
+config-version: 2


### PR DESCRIPTION
The title speaks for itself. Added to make update process easy. If the plugin has some changes to config file structure, version number should be increased. The plugin then will check and if the versions does not match it will back up the old config and create new default one